### PR TITLE
Traverse nodes nested under control nodes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
   specs:
     ast (2.4.2)
     diff-lcs (1.5.0)
-    hamli (0.2.0)
+    hamli (0.5.1)
       temple
     parallel (1.21.0)
     parser (3.1.0.0)

--- a/lib/hamlcop/ruby_extractor.rb
+++ b/lib/hamlcop/ruby_extractor.rb
@@ -59,12 +59,10 @@ module Hamlcop
     def traverse(node, &block)
       return unless node.instance_of?(::Array)
 
-      if node[0] == :hamli && node[1] == :position
-        block.call(node[2], node[3])
-      else
-        node.each do |element|
-          traverse(element, &block)
-        end
+      block.call(node[2], node[3]) if node[0] == :hamli && node[1] == :position
+
+      node.each do |element|
+        traverse(element, &block)
       end
     end
   end

--- a/spec/hamlcop/ruby_extractor_spec.rb
+++ b/spec/hamlcop/ruby_extractor_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Hamlcop::RubyExtractor do
+  subject { described_class.new(file_path: file_path, source: source).call }
+
+  let(:file_path) { '/tmp/test.rb' }
+
+  let(:source) do
+    raise NotImplementedError
+  end
+
+  context 'with code nested under a control node' do
+    let(:source) do
+      <<~HAML
+        - 5.times do |n|
+          %th{colspan: 2}= n
+      HAML
+    end
+
+    it 'detects also the nested nodes' do
+      is_expected.to eq([
+                          { code: '5.times', offset: 2 },
+                          { code: '{colspan: 2}', offset: 22 },
+                          { code: 'n', offset: 36 }
+                        ])
+    end
+  end
+end


### PR DESCRIPTION
Given the HAML template

```haml
- 5.times do |n|
  %th{colspan: 2}= n
```

the Ruby extractor would only detect

```ruby
[
  { code: '5.times', offset: 2 }
]
```

and stop traversing the subtree.

We make it traverse the subtree as well and now it finds

```ruby
[
  { code: '5.times', offset: 2 },
  { code: '{colspan: 2}', offset: 22 },
  { code: 'n', offset: 36 }
]
```